### PR TITLE
add full scan API

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -172,6 +172,7 @@
     "strstream": "cpp",
     "complex": "cpp",
     "cfenv": "cpp",
-    "typeindex": "cpp"
+    "typeindex": "cpp",
+    "source_location": "cpp"
   },
 }

--- a/src/common.hpp
+++ b/src/common.hpp
@@ -42,6 +42,7 @@ enum IndexOperation {
   kUndefinedOperation = -1,
   kRead,
   kScan,
+  kFullScan,
   kWrite,
   kInsert,
   kUpdate,
@@ -58,6 +59,7 @@ NLOHMANN_JSON_SERIALIZE_ENUM(IndexOperation,
                                  {kUndefinedOperation, nullptr},
                                  {kRead, "read"},
                                  {kScan, "scan"},
+                                 {kFullScan, "full scan"},
                                  {kWrite, "write"},
                                  {kInsert, "insert"},
                                  {kUpdate, "update"},
@@ -104,7 +106,13 @@ NLOHMANN_JSON_SERIALIZE_ENUM(Partitioning,
  * @brief A list of the size of target keys.
  *
  */
-enum KeySize { k8 = 8, k16 = 16, k32 = 32, k64 = 64, k128 = 128 };
+enum KeySize {
+  k8 = 8,
+  k16 = 16,
+  k32 = 32,
+  k64 = 64,
+  k128 = 128,
+};
 
 constexpr size_t kMaxCoreNum = INDEX_BENCH_MAX_CORES;
 

--- a/src/index.hpp
+++ b/src/index.hpp
@@ -177,6 +177,9 @@ class Index
       case kScan:
         index_->Scan(ops.GetKey(), ops.GetPayload());
         break;
+      case kFullScan:
+        index_->FullScan();
+        break;
       case kWrite:
         index_->Write(ops.GetKey(), ops.GetPayload());
         break;

--- a/src/indexes/btree_olc_wrapper.hpp
+++ b/src/indexes/btree_olc_wrapper.hpp
@@ -92,6 +92,12 @@ class BTreeOLCWrapper
     throw std::runtime_error{"ERROR: the scan operation is not implemented."};
   }
 
+  void
+  FullScan()
+  {
+    throw std::runtime_error{"ERROR: the scan operation is not implemented."};
+  }
+
   auto
   Write(  //
       const Key &key,

--- a/src/indexes/index_wrapper.hpp
+++ b/src/indexes/index_wrapper.hpp
@@ -97,6 +97,15 @@ class IndexWrapper
     }
   }
 
+  void
+  FullScan()
+  {
+    size_t sum{0};
+    for (auto &&iter = index_->Scan(); iter.HasNext(); ++iter) {
+      sum += iter.GetPayload();
+    }
+  }
+
   auto
   Write(  //
       const Key &key,

--- a/src/indexes/masstree_wrapper.hpp
+++ b/src/indexes/masstree_wrapper.hpp
@@ -150,6 +150,12 @@ class MasstreeWrapper
     throw std::runtime_error{"ERROR: the scan operation is not implemented."};
   }
 
+  void
+  FullScan()
+  {
+    throw std::runtime_error{"ERROR: the scan operation is not implemented."};
+  }
+
   auto
   Write(  //
       const Key &key,

--- a/src/indexes/open_bw_tree_wrapper.hpp
+++ b/src/indexes/open_bw_tree_wrapper.hpp
@@ -130,6 +130,21 @@ class OpenBwTreeWrapper
     }
   }
 
+  void
+  Scan()
+  {
+    const auto &&end_key = begin_key + scan_range;
+    size_t sum{0};
+
+    ForwardIterator tree_iterator{&index_, begin_key};
+    for (; !tree_iterator.IsEnd(); ++tree_iterator) {
+      const auto &[key, value] = *tree_iterator;
+      if (end_key < key) break;
+
+      sum += value;
+    }
+  }
+
   auto
   Write(  //
       const Key &key,

--- a/workload/full_scan.json
+++ b/workload/full_scan.json
@@ -1,0 +1,17 @@
+{
+  "initialization": {
+    "# of keys": 100000000,
+    "use all cores": true
+  },
+  "workloads": [
+    {
+      "operation ratios": {
+        "full scan": 1.0
+      },
+      "# of keys": 100000000,
+      "partitioning policy": "none",
+      "access pattern": "random",
+      "skew parameter": 0.0
+    }
+  ]
+}


### PR DESCRIPTION
@nrkt 
実装し忘れていたfull scan用のAPIを追加しました．わりと愉快な性能です．このままマージするので，手元のソースに反映しておいてください．

```txt
sugiura@giants:~/workspace/cpp/index-benchmark
: (add-full-scan *$%) 10:45:36 [EXIT=0]
$ ./build/Release/index_bench --num-exec 1000 --num-thread 56 --workload workload/full_scan.json --b-pml
*** START B+tree based on PML ***
...Prepare workers for benchmarking.
...Run workers.
...Finish running.
Throughput [Ops/s]: 101.153
*** FINISH ***

sugiura@giants:~/workspace/cpp/index-benchmark
: (add-full-scan *$%) 10:47:28 [EXIT=0]
$ ./build/Release/index_bench --num-exec 1000 --num-thread 56 --workload workload/full_scan.json --b-osl
*** START B+tree based on OSL ***
...Prepare workers for benchmarking.
...Run workers.
...Finish running.
Throughput [Ops/s]: 73.2234
*** FINISH ***

sugiura@giants:~/workspace/cpp/index-benchmark
: (add-full-scan *$%) 10:48:29 [EXIT=0]
$ ./build/Release/index_bench --num-exec 1000 --num-thread 56 --workload workload/full_scan.json --bw
*** START Bw-tree ***
...Prepare workers for benchmarking.
...Run workers.
...Finish running.
Throughput [Ops/s]: 31.2254
*** FINISH ***

sugiura@giants:~/workspace/cpp/index-benchmark
: (add-full-scan *$%) 10:49:17 [EXIT=0]
$ ./build/Release/index_bench --num-exec 1000 --num-thread 56 --workload workload/full_scan.json --bz-in-place
*** START BzTree in-place mode ***
...Prepare workers for benchmarking.
...Run workers.
...Finish running.
Throughput [Ops/s]: 21.7698
*** FINISH ***
```